### PR TITLE
Add mas and cask_args to keywords

### DIFF
--- a/syntax/brewfile.vim
+++ b/syntax/brewfile.vim
@@ -12,7 +12,7 @@ endif
 source $VIMRUNTIME/syntax/ruby.vim
 unlet b:current_syntax
 
-syn keyword brewfileDirective brew cask tap
+syn keyword brewfileDirective brew cask tap mas cask_args
 
 hi def link brewfileDirective Keyword
 


### PR DESCRIPTION
Brewfile DSL additionally specifies 'mas' and 'cask_args' keywords. So adding them as here for proper syntax highlighting.